### PR TITLE
feat(security): enable Docker image digest pinning (Ops/security Phase 0.4)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "prHourlyLimit": 4,
   "prConcurrentLimit": 6,
   "labels": ["renovate", "dependencies"],
+  "pinDigests": true,
   "docker": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary

- Enable Renovate `pinDigests` for immutable Docker image digest PRs.
- Keeps existing Renovate grouping and schedule unchanged.

## Validation

- Config option checked against official Renovate configuration docs.
- No local tests or lint run, per workstation instruction to run tests/lint only after approval.