### PR TITLE
fix(db): add migration to rename translation tables (#9 root cause)

### DIFF
--- a/app/lib/Migration/Version007900Date20260430000000.php
+++ b/app/lib/Migration/Version007900Date20260430000000.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+namespace OCA\Learning\Migration;
+
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Issue #9: Sync DB table names with what the Mapper classes have been
+ * referring to since v3.5.0 (commit 7016ddd, 2026-03-29).
+ *
+ * That commit renamed the table identifiers in the Mapper classes:
+ *   learning_q_translations -> learning_qst_translations
+ *   learning_a_translations -> learning_ans_translations
+ * but never shipped a migration to rename the tables themselves. As a
+ * result, every fresh install since v3.5.0 ended up with the original
+ * names from Version000350 in the database, while the code looked for
+ * the renamed identifiers — producing SQLSTATE[42S02] / 1146 "table not
+ * found" once any Mapper / raw query touched the translations.
+ *
+ * This migration is idempotent: it only renames when the old name still
+ * exists and the new name does not yet. Installs that were patched
+ * manually (old absent, new present) and fresh installs running this
+ * migration first time are both correctly handled.
+ */
+class Version007900Date20260430000000 extends SimpleMigrationStep {
+
+    private IDBConnection $db;
+
+    public function __construct(IDBConnection $db) {
+        $this->db = $db;
+    }
+
+    public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options): void {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+        $prefix = method_exists($this->db, 'getPrefix') ? $this->db->getPrefix() : 'oc_';
+
+        if ($schema->hasTable('learning_q_translations') && !$schema->hasTable('learning_qst_translations')) {
+            $this->db->executeStatement(
+                "ALTER TABLE {$prefix}learning_q_translations RENAME TO {$prefix}learning_qst_translations"
+            );
+            $output->info('Renamed learning_q_translations -> learning_qst_translations (issue #9)');
+        }
+
+        if ($schema->hasTable('learning_a_translations') && !$schema->hasTable('learning_ans_translations')) {
+            $this->db->executeStatement(
+                "ALTER TABLE {$prefix}learning_a_translations RENAME TO {$prefix}learning_ans_translations"
+            );
+            $output->info('Renamed learning_a_translations -> learning_ans_translations (issue #9)');
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes the **root cause** of [#9](https://github.com/andremadstop/learning-nc/issues/9) — the smoking-gun stacktrace from BrdrTck on MariaDB 10.11 / NC 33.0.2 / v4.4.0 confirms it: `Table 'Ty8aj_learning_qst_translations' doesn't exist`.

Commit [7016ddd](https://github.com/andremadstop/learning-nc/commit/7016ddd) (v3.5.0, 2026-03-29) renamed the table identifiers in two Mapper classes:

| Mapper | Old | New |
| --- | --- | --- |
| `QuestionTranslationMapper` | `learning_q_translations` | `learning_qst_translations` |
| `AnswerTranslationMapper`   | `learning_a_translations` | `learning_ans_translations` |

…but **shipped no schema migration to actually rename the tables in the database**. So every fresh install since v3.5.0 has the original names from `Version000350` in the DB while the code looks for the renamed ones → `SQLSTATE[42S02]` / `1146`.

It only worked on the dev cloud because the tables there were renamed manually at some point. CI / fresh installs were broken.

## Changes
- New migration `Version007900Date20260430000000` — idempotent rename for both tables. Only acts when the old name still exists and the new one does not.

## Test plan
- [x] PHP-lint clean
- [x] PHPStan Level 5 clean (full project)
- [ ] Manual: bump version in info.xml → `occ upgrade` on a fresh MariaDB install → confirm tables exist under new names and `GET /apps/learning/api/courses/{id}` returns 200 once a pool is attached
- [ ] Reporter (BrdrTck) confirms the issue is gone after upgrading to v4.4.1

## Notes
This is the proper fix. PR #11 (defensive try/catch in `CourseService::findById`) is its safety net for any future drift of this kind.

There is a similar latent drift on `learning_curriculum_scopes` → `learning_course_curriculum_scopes` (also from 7016ddd). The new name exceeds NC's 27-char table-name limit so it cannot just be ALTERed in. Tracking separately — out of scope for this PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)