### PR TITLE
fix(db): make migration 007900 self-healing — hotfix for v4.4.1 upgrade crash (#9)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.4.2] - 2026-04-30 — Hotfix for Issue #9 migration crash
+
+### Fixed
+- **Migration `Version007900` is now self-healing.** v4.4.1 attempted a simple `ALTER TABLE … RENAME TO …`, which crashed with `1146 Table 'oc_learning_q_translations' doesn't exist` on installs where `Version000350` had silently failed and the legacy table was never created in the first place — blocking the upgrade entirely. The migration now checks the real DB state via `information_schema` (not the Doctrine schema cache) and handles three states: new table already exists → no-op; legacy table exists → `ALTER TABLE` rename inside try/catch; neither exists → `CREATE TABLE` from scratch as recovery. MariaDB / MySQL, PostgreSQL and SQLite all supported.
+- Reported by @BrdrTck on the v4.4.1 upgrade attempt.
+
 ## [4.4.1] - 2026-04-30 — Bugfixes (Issue #9 + #10)
 
 ### Fixed

--- a/app/appinfo/info.xml
+++ b/app/appinfo/info.xml
@@ -64,7 +64,7 @@ Requires a Google Gemini API key. Without it, the app is fully functional — AI
 **Looking for pilot partners!** If you run Nextcloud at a school, university, or training provider — we'd love your feedback. Demo available.
     ]]></description>
 
-    <version>4.4.1</version>
+    <version>4.4.2</version>
     <licence>agpl</licence>
     <author mail="dev@quizdojo.com" homepage="https://github.com/andremadstop">Andre</author>
     <namespace>Learning</namespace>

--- a/app/lib/Migration/Version007900Date20260430000000.php
+++ b/app/lib/Migration/Version007900Date20260430000000.php
@@ -14,16 +14,26 @@ use OCP\Migration\SimpleMigrationStep;
  * That commit renamed the table identifiers in the Mapper classes:
  *   learning_q_translations -> learning_qst_translations
  *   learning_a_translations -> learning_ans_translations
- * but never shipped a migration to rename the tables themselves. As a
- * result, every fresh install since v3.5.0 ended up with the original
- * names from Version000350 in the database, while the code looked for
- * the renamed identifiers — producing SQLSTATE[42S02] / 1146 "table not
- * found" once any Mapper / raw query touched the translations.
+ * but never shipped a migration to rename the tables themselves. So
+ * every fresh install since v3.5.0 ended up with the original names
+ * from Version000350 in the database, while the code looked for the
+ * renamed identifiers — producing SQLSTATE[42S02] / 1146 once a Mapper
+ * touched the translations.
  *
- * This migration is idempotent: it only renames when the old name still
- * exists and the new name does not yet. Installs that were patched
- * manually (old absent, new present) and fresh installs running this
- * migration first time are both correctly handled.
+ * v4.4.1 attempted a simple `ALTER TABLE RENAME` but assumed the legacy
+ * table existed. On installs where Version000350 had silently failed
+ * (no legacy table either) the rename crashed with 1146, blocking the
+ * upgrade entirely. v4.4.2 makes the migration self-healing across all
+ * three states:
+ *
+ *   1. New table already exists       -> no-op
+ *   2. Old table exists, new doesn't  -> ALTER TABLE RENAME
+ *   3. Neither exists                 -> CREATE TABLE (recovers from
+ *                                        a historical Version000350 fail)
+ *
+ * Existence is checked against the real DB via information_schema, not
+ * against the Doctrine schema cache, because the two can disagree on
+ * installs that have skipped or failed earlier migrations.
  */
 class Version007900Date20260430000000 extends SimpleMigrationStep {
 
@@ -34,22 +44,129 @@ class Version007900Date20260430000000 extends SimpleMigrationStep {
     }
 
     public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options): void {
-        /** @var ISchemaWrapper $schema */
-        $schema = $schemaClosure();
         $prefix = method_exists($this->db, 'getPrefix') ? $this->db->getPrefix() : 'oc_';
 
-        if ($schema->hasTable('learning_q_translations') && !$schema->hasTable('learning_qst_translations')) {
-            $this->db->executeStatement(
-                "ALTER TABLE {$prefix}learning_q_translations RENAME TO {$prefix}learning_qst_translations"
-            );
-            $output->info('Renamed learning_q_translations -> learning_qst_translations (issue #9)');
+        $this->ensureTable(
+            $prefix,
+            'learning_q_translations',
+            'learning_qst_translations',
+            'question_id',
+            'learn_qt_question_idx',
+            'learn_qt_q_lang_uniq',
+            true,
+            $output
+        );
+
+        $this->ensureTable(
+            $prefix,
+            'learning_a_translations',
+            'learning_ans_translations',
+            'answer_id',
+            'learn_at_answer_idx',
+            'learn_at_a_lang_uniq',
+            false,
+            $output
+        );
+    }
+
+    private function ensureTable(
+        string $prefix,
+        string $oldName,
+        string $newName,
+        string $foreignKeyColumn,
+        string $foreignKeyIndex,
+        string $uniqueIndex,
+        bool $hasExplanation,
+        IOutput $output
+    ): void {
+        $oldFull = $prefix . $oldName;
+        $newFull = $prefix . $newName;
+
+        if ($this->tableExists($newFull)) {
+            return;
         }
 
-        if ($schema->hasTable('learning_a_translations') && !$schema->hasTable('learning_ans_translations')) {
-            $this->db->executeStatement(
-                "ALTER TABLE {$prefix}learning_a_translations RENAME TO {$prefix}learning_ans_translations"
-            );
-            $output->info('Renamed learning_a_translations -> learning_ans_translations (issue #9)');
+        if ($this->tableExists($oldFull)) {
+            try {
+                $this->db->executeStatement("ALTER TABLE {$oldFull} RENAME TO {$newFull}");
+                $output->info("Renamed {$oldName} -> {$newName} (issue #9)");
+                return;
+            } catch (\Throwable $e) {
+                $output->warning("Rename {$oldName} -> {$newName} failed: " . $e->getMessage() . " — attempting create-from-scratch");
+            }
+        }
+
+        // Fallback: create the table from scratch. Recovers from installs
+        // where Version000350 historically failed and left no legacy table.
+        $explanationCol = $hasExplanation ? "`explanation` TEXT NULL," : '';
+        $sql = "
+            CREATE TABLE {$newFull} (
+                `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                `{$foreignKeyColumn}` BIGINT UNSIGNED NOT NULL,
+                `lang` VARCHAR(10) NOT NULL,
+                `text` LONGTEXT NOT NULL,
+                {$explanationCol}
+                `created_at` BIGINT UNSIGNED NULL,
+                PRIMARY KEY (`id`),
+                INDEX `{$foreignKeyIndex}` (`{$foreignKeyColumn}`),
+                UNIQUE INDEX `{$uniqueIndex}` (`{$foreignKeyColumn}`, `lang`)
+            )
+        ";
+
+        $platform = $this->db->getDatabasePlatform()->getName();
+        if ($platform === 'postgresql') {
+            $explanationColPg = $hasExplanation ? '"explanation" TEXT NULL,' : '';
+            $sql = "
+                CREATE TABLE \"{$newFull}\" (
+                    \"id\" BIGSERIAL PRIMARY KEY,
+                    \"{$foreignKeyColumn}\" BIGINT NOT NULL,
+                    \"lang\" VARCHAR(10) NOT NULL,
+                    \"text\" TEXT NOT NULL,
+                    {$explanationColPg}
+                    \"created_at\" BIGINT NULL
+                )
+            ";
+            $this->db->executeStatement($sql);
+            $this->db->executeStatement("CREATE INDEX \"{$foreignKeyIndex}\" ON \"{$newFull}\" (\"{$foreignKeyColumn}\")");
+            $this->db->executeStatement("CREATE UNIQUE INDEX \"{$uniqueIndex}\" ON \"{$newFull}\" (\"{$foreignKeyColumn}\", \"lang\")");
+        } elseif ($platform === 'sqlite') {
+            $explanationColSq = $hasExplanation ? '"explanation" TEXT,' : '';
+            $sql = "
+                CREATE TABLE \"{$newFull}\" (
+                    \"id\" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    \"{$foreignKeyColumn}\" INTEGER NOT NULL,
+                    \"lang\" TEXT NOT NULL,
+                    \"text\" TEXT NOT NULL,
+                    {$explanationColSq}
+                    \"created_at\" INTEGER
+                )
+            ";
+            $this->db->executeStatement($sql);
+            $this->db->executeStatement("CREATE INDEX \"{$foreignKeyIndex}\" ON \"{$newFull}\" (\"{$foreignKeyColumn}\")");
+            $this->db->executeStatement("CREATE UNIQUE INDEX \"{$uniqueIndex}\" ON \"{$newFull}\" (\"{$foreignKeyColumn}\", \"lang\")");
+        } else {
+            $this->db->executeStatement($sql);
+        }
+
+        $output->info("Created {$newName} from scratch (issue #9 recovery — neither legacy nor new table existed)");
+    }
+
+    private function tableExists(string $fullyQualifiedName): bool {
+        $platform = $this->db->getDatabasePlatform()->getName();
+        try {
+            if ($platform === 'sqlite') {
+                $sql = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?";
+            } elseif ($platform === 'postgresql') {
+                $sql = "SELECT 1 FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = ?";
+            } else {
+                $sql = "SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?";
+            }
+            $result = $this->db->executeQuery($sql, [$fullyQualifiedName]);
+            $exists = (bool)$result->fetchOne();
+            $result->closeCursor();
+            return $exists;
+        } catch (\Throwable $e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
Hotfix for [#9](https://github.com/andremadstop/learning-nc/issues/9). v4.4.1's `Version007900` migration crashed with `SQLSTATE[42S02] / 1146 Table 'oc_learning_q_translations' doesn't exist` on @BrdrTck's MariaDB install, blocking the upgrade entirely. Root cause: `Version000350` had silently failed historically on his install, so the legacy table never existed in the first place — the v4.4.1 rename had no source.

## Changes
Migration now handles three states explicitly:
- new table already exists → no-op
- legacy table exists → `ALTER TABLE RENAME` inside try/catch
- neither exists → `CREATE TABLE` from scratch (recovery)

Existence is checked against the real DB via `information_schema` (or `sqlite_master`), not via the Doctrine schema cache, since the two can disagree on installs that have skipped or failed earlier migrations. MariaDB / MySQL, PostgreSQL and SQLite all supported.

Bumps to v4.4.2.

## Test plan
- [x] PHP-lint clean
- [x] PHPStan Level 5 clean
- [x] `tableExists` query verified against PostgreSQL on devcloud
- [ ] Manual: BrdrTck re-runs `occ upgrade` after v4.4.2 hits the App Store

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)